### PR TITLE
Removing public-read action

### DIFF
--- a/.github/workflows/release_catalog.yml
+++ b/.github/workflows/release_catalog.yml
@@ -68,4 +68,4 @@ jobs:
 
         - name: Allow public read access to file in S3 bucket
           run: |
-             aws s3api put-object-acl --bucket ${{ secrets.PROD_AWS_S3_BUCKET }} --key catalog.json --acl public-read
+             aws s3api put-object-acl --bucket ${{ secrets.PROD_AWS_S3_BUCKET }} --key catalog.json

--- a/.github/workflows/release_catalog.yml
+++ b/.github/workflows/release_catalog.yml
@@ -65,7 +65,3 @@ jobs:
           env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-        - name: Allow public read access to file in S3 bucket
-          run: |
-             aws s3api put-object-acl --bucket ${{ secrets.PROD_AWS_S3_BUCKET }} --key catalog.json


### PR DESCRIPTION
ACLs are already applied to the directories in the cohesive-networks prod bucket.  This additional action results in an error because the bucket does not have public read permissions enabled.